### PR TITLE
When a codelist name is available, use it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,22 @@
 // Import libraries
-const util = require("util")
-const Fs = require("fs")
-const Path = require("path")
+const Fs = require('fs')
 const fsExtra = require('fs-extra')
 
-console.log('Parsing codelists...');
+console.log('Parsing codelists...')
 
 // Create file to write to
 
-const createWriteStream = function(folder) {
+const createWriteStream = function (folder) {
   fsExtra.ensureDirSync(folder)
   return Fs.createWriteStream(`${folder}/README.md`)
 }
 
 // Write to file
 
-const createMarkdownFiles = async() => {
-  Fs.readFile('docs/.vuepress/public/clv3/codelists.json', 'utf8', function(err, data) {
-    if (err) throw err;
-    codelists = JSON.parse(data)
+const createMarkdownFiles = async () => {
+  Fs.readFile('docs/.vuepress/public/clv3/codelists.json', 'utf8', function (err, data) {
+    if (err) { throw err }
+    var codelists = JSON.parse(data)
     codelists.sort()
     codelists.forEach(codelistSlug => {
       ['en', 'fr'].forEach(lang => {
@@ -40,9 +38,9 @@ title: ${codelistName}
   })
 }
 
-const setup = async() => {
-  fsExtra.emptyDirSync("docs/")
-  fsExtra.copySync("static/", "docs/")
+const setup = async () => {
+  fsExtra.emptyDirSync('docs/')
+  fsExtra.copySync('static/', 'docs/')
 }
 
 const addToLocales = async (codelistSlug, codelistName, lang) => {
@@ -52,8 +50,8 @@ const addToLocales = async (codelistSlug, codelistName, lang) => {
   } else {
     locales[`/${lang}/`].sidebar.push([`/${lang}/${codelistSlug}/`, codelistName])
   }
-  Fs.writeFileSync("docs/.vuepress/locales.json", JSON.stringify(locales))
+  Fs.writeFileSync('docs/.vuepress/locales.json', JSON.stringify(locales))
 }
 
-//setup()
+// setup()
 createMarkdownFiles()

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,6 @@ const createMarkdownFiles = async () => {
           const folderPath = `docs${path}${codelistSlug}`
           const stream = createWriteStream(folderPath)
           stream.write(`---
-title: ${codelistName}
 ---
 <CodelistPage codelist="${codelistSlug}" lang="${lang}"/>`)
         })

--- a/static/.vuepress/components/CodelistPage.vue
+++ b/static/.vuepress/components/CodelistPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-row>
-      <b-col md="8"><h2>{{ title }}</h2></b-col>
+      <b-col md="8"><h2>{{ this.$frontmatter.title }}</h2></b-col>
       <b-col md="4" class="text-right">
         <b-dropdown :text="this.$themeLocaleConfig.download" right>
           <b-dropdown-item v-for="downloadURL in downloadURLs" :href="downloadURL.url">{{ downloadURL.format }}</b-dropdown-item>
@@ -39,7 +39,6 @@
     props: ['codelist', 'lang'],
     data () {
       return {
-        title: "",
         description: null,
         categoryCodelist: null,
         url: null,
@@ -58,7 +57,6 @@
         }
       })
       this.codes = data.data.data
-      this.title = data.data.attributes.name
       this.description = (data.data.metadata.description != "") ? data.data.metadata.description : null
       this.categoryCodelist = data.data.attributes["category-codelist"] ? data.data.attributes["category-codelist"] : null
       this.url = data.data.metadata.url ? data.data.metadata.url : null

--- a/static/.vuepress/components/CodelistPage.vue
+++ b/static/.vuepress/components/CodelistPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-row>
-      <b-col md="8"><h2>{{ this.$frontmatter.title }}</h2></b-col>
+      <b-col md="8"><h2>{{ title }}</h2></b-col>
       <b-col md="4" class="text-right">
         <b-dropdown :text="this.$themeLocaleConfig.download" right>
           <b-dropdown-item v-for="downloadURL in downloadURLs" :href="downloadURL.url">{{ downloadURL.format }}</b-dropdown-item>
@@ -40,6 +40,7 @@
     data () {
       return {
         description: null,
+        title: "",
         categoryCodelist: null,
         url: null,
         codes: [],
@@ -57,6 +58,7 @@
         }
       })
       this.codes = data.data.data
+      this.title = data.data.metadata.name || data.data.attributes.name
       this.description = (data.data.metadata.description != "") ? data.data.metadata.description : null
       this.categoryCodelist = data.data.attributes["category-codelist"] ? data.data.attributes["category-codelist"] : null
       this.url = data.data.metadata.url ? data.data.metadata.url : null


### PR DESCRIPTION
This changes the codelist page titles and the sidebar, to use the codelist name when it’s available (currently, it’s always available in English and never available in French).