### PR TITLE
Generalise custom namespaces

### DIFF
--- a/src/gen.py
+++ b/src/gen.py
@@ -16,9 +16,6 @@ import xlsx
 languages = ['en', 'fr']
 
 xml_lang = '{http://www.w3.org/XML/1998/namespace}lang'
-budget_alignment_namespace = {
-    'budget-alignment': 'http://iatistandard.org/activity-standard/' +
-                        'overview/country-budget-alignment/'}
 nsmap = {'xml': 'http://www.w3.org/XML/1998/namespace'}
 
 repo = git.Repo('IATI-Codelists-NonEmbedded/.git')
@@ -54,6 +51,9 @@ def codelist_item_todict(codelist_item, default_lang='',
     out = {}
     for child in codelist_item:
         el_name = child.tag
+        if child.prefix is not None:
+            el_name = '{}:{}'.format(
+                child.prefix, child.tag.split('}')[1])
         if child.find('narrative') is not None:
             if lang == default_lang:
                 narrative = child.xpath(
@@ -78,14 +78,6 @@ def codelist_item_todict(codelist_item, default_lang='',
         else:
             out['public-database'] = False
     out['status'] = codelist_item.get('status', 'active')
-    if codelist_name == 'Sector':
-        budget_alignment_status = codelist_item.find(
-            'budget-alignment:status',
-            namespaces=budget_alignment_namespace)
-        if budget_alignment_status is not None:
-            out['budget_alignment_guidance'] = budget_alignment_status.text
-        else:
-            out['budget_alignment_guidance'] = ''
     return out
 
 
@@ -167,6 +159,12 @@ for language in languages:
             fieldnames,
             key=lambda x: (fieldname_order.index(x)
                            if x in fieldname_order else 100))
+
+        # ensure every codelist dict contains all fields
+        for codelist_dict in codelist_dicts:
+            for fieldname in fieldnames:
+                if fieldname not in codelist_dict:
+                    codelist_dict[fieldname] = ''
 
         csv_filename = join(
             OUTPUTDIR, 'csv', language, attrib['name'] + '.csv')

--- a/src/gen.py
+++ b/src/gen.py
@@ -164,7 +164,7 @@ for language in languages:
         for codelist_dict in codelist_dicts:
             for fieldname in fieldnames:
                 if fieldname not in codelist_dict:
-                    codelist_dict[fieldname] = ''
+                    codelist_dict[fieldname] = None
 
         csv_filename = join(
             OUTPUTDIR, 'csv', language, attrib['name'] + '.csv')

--- a/static/.vuepress/components/CodelistPage.vue
+++ b/static/.vuepress/components/CodelistPage.vue
@@ -112,7 +112,7 @@
       rowClass(item, type) {
         if (!item) return
         if (item.status === 'withdrawn') return 'withdrawn-code'
-        if ((item.budget_alignment_guidance) && (item.budget_alignment_guidance != "")) return 'table-danger'
+        if ((item['budget-alignment:status']) && (item['budget-alignment:status'] != "")) return 'table-danger'
       },
       statusFormatter(value) {
         return this.columnFormatter('status', value)

--- a/static/.vuepress/locales.json
+++ b/static/.vuepress/locales.json
@@ -14,7 +14,7 @@
     "categorisedCodelist": "This codelist is grouped into categories, using the codelist",
     "source": "Original source",
     "headers": {
-      "budget_alignment_guidance": "Guidance"
+      "budget-alignment:status": "Guidance"
     }
   },
   "/fr/": {
@@ -37,7 +37,7 @@
       "category": "Catégorie",
       "description": "Description",
       "status": "Statut",
-      "budget_alignment_guidance": "Guidance"
+      "budget-alignment:status": "Guidance"
     },
     "columnValues": {
       "status": {

--- a/static/.vuepress/locales.json
+++ b/static/.vuepress/locales.json
@@ -14,6 +14,17 @@
     "categorisedCodelist": "This codelist is grouped into categories, using the codelist",
     "source": "Original source",
     "headers": {
+      "url": "URL",
+      "codeforiati:iso-alpha-2-code": "ISO alpha-2 code",
+      "codeforiati:iso-alpha-3-code": "ISO alpha-3 code",
+      "codeforiati:global-code": "Global code",
+      "codeforiati:global-name": "Global name",
+      "codeforiati:region-code": "Region code",
+      "codeforiati:region-name": "Region name",
+      "codeforiati:sub-region-code": "Sub-region code",
+      "codeforiati:sub-region-name": "Sub-region name",
+      "codeforiati:intermediate-region-code": "Intermediate region code",
+      "codeforiati:intermediate-region-name": "Intermediate region name",
       "budget-alignment:status": "Guidance"
     }
   },
@@ -36,7 +47,18 @@
       "name": "Nom",
       "category": "Catégorie",
       "description": "Description",
+      "url": "URL",
       "status": "Statut",
+      "codeforiati:iso-alpha-2-code": "ISO alpha-2 code",
+      "codeforiati:iso-alpha-3-code": "ISO alpha-3 code",
+      "codeforiati:global-code": "Global code",
+      "codeforiati:global-name": "Global name",
+      "codeforiati:region-code": "Region code",
+      "codeforiati:region-name": "Region name",
+      "codeforiati:sub-region-code": "Sub-region code",
+      "codeforiati:sub-region-name": "Sub-region name",
+      "codeforiati:intermediate-region-code": "Intermediate region code",
+      "codeforiati:intermediate-region-name": "Intermediate region name",
       "budget-alignment:status": "Guidance"
     },
     "columnValues": {


### PR DESCRIPTION
Rather than a special case solution for custom namespaces (currently just used for budget alignment guidance in the sector codelist) this PR generalises this to work for any custom namespace.

Note that this affects the Sector codelist in a couple of ways:
 * The `budget_alignment_guidance` column is renamed to `budget-alignment:status`
 * Missing budget alignment values in the JSON were previously set to empty string, but are now set to null