### PR TITLE
Throw away gh-pages history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.TOKEN }}
         BRANCH: gh-pages
         FOLDER: docs/.vuepress/dist
+        SINGLE_COMMIT: true
         CLEAN: true


### PR DESCRIPTION
Just keep the most recent commit.

## Why?

This repo is really massive – presumably because the gh-pages branch has lots of big commits. I don’t know how useful they are, really.