### PR TITLE
Generate ES codelists in API

### DIFF
--- a/src/gen.py
+++ b/src/gen.py
@@ -15,7 +15,7 @@ import xlsx
 VERSION = sys.argv[1]
 OUTPUTDIR = sys.argv[2]
 
-languages = ['en', 'fr']
+languages = ['en', 'fr', 'es']
 
 xml_lang = '{http://www.w3.org/XML/1998/namespace}lang'
 nsmap = {'xml': 'http://www.w3.org/XML/1998/namespace'}


### PR DESCRIPTION
Just add `es` to generate ES codelist files. We can subsequently generate the front end if we want / when we are ready.