### PR TITLE
Break word on URL and description columns

### DIFF
--- a/static/.vuepress/components/CodelistPage.vue
+++ b/static/.vuepress/components/CodelistPage.vue
@@ -146,6 +146,9 @@
   .category-item:last-child:after {
     content: ""
   }
+  .url, .description {
+    word-break: break-word;
+  }
 </style>
 <script>
   import axios from 'axios'
@@ -177,6 +180,7 @@
         var f = {
           key: field,
           sortable: true,
+          tdClass: ['description', 'url'].includes(field) ? field : null,
           label: this.$themeLocaleConfig.headers[field] ? this.$themeLocaleConfig.headers[field] : null
         }
         if (field == 'status') {


### PR DESCRIPTION
This:
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/688113/214115512-5efc2dfc-f5fa-4021-a3c8-2ef40d85d8c0.png">

Looks like this:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/688113/214115704-bc4f04f3-2bb6-44fa-8f9d-2d459eda2354.png">

(Which isn't perfect, but is definitely more readable!)