### PR TITLE
Add locale to key to ensure data is refreshed when locale changes

### DIFF
--- a/app/components/Sidebar.vue
+++ b/app/components/Sidebar.vue
@@ -34,7 +34,7 @@
 const { locale } = useI18n()
 const localePath = useLocalePath()
 const main = useStore()
-const { data: navigation } = await useAsyncData('navigation', () => {
+const { data: navigation } = await useAsyncData('navigation' + locale.value, () => {
   return queryCollectionNavigation('content_' + locale.value)
 }, {
   watch: [locale], // Refetch when locale changes

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -26,7 +26,7 @@ const codelistPageName = computed(() => {
 })
 const codelist = computed(() => { return main.codelists.includes(codelistPageName.value) })
 
-const { data: page } = await useAsyncData('page-' + slug.value, async () => {
+const { data: page } = await useAsyncData('page-' + slug.value + locale.value, async () => {
     // Build collection name based on current locale
     const collection = ('content_' + locale.value) as keyof Collections
     const content = await queryCollection(collection).path(slug.value).first()


### PR DESCRIPTION
Fixing bug whereby markdown pages are otherwise not loaded in the correct language according to the locale.