### PR TITLE
Show shorter title on the top of the page

### DIFF
--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -43,11 +43,11 @@ const { data: page } = await useAsyncData(() => `page-${slug.value}-${locale.val
 
 const pageTitle = computed(() => {
     if (page.value) {
-        return `${page.value?.title} | ${t('title')}`
+        return `${page.value?.title} | ${t('siteTitle')}`
     } else if (codelist) {
-        return `${codelistPageName.value} | ${t('title')}`
+        return `${codelistPageName.value} | ${t('siteTitle')}`
     } else {
-        return t('title')
+        return t('siteTitle')
     }
 })
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "lang": "en",
-  "title": "Code for IATI Codelists",
+  "siteTitle": "Code for IATI Codelists",
+  "title": "Codelists",
   "description": "Useful codelists when using IATI data",
   "selectText": "Languages",
   "label": "English",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1,6 +1,7 @@
 {
   "lang": "fr",
-  "title": "Code for IATI Listes de codes",
+  "siteTitle": "Code for IATI Listes de codes",
+  "title": "Listes de codes",
   "description": "Listes de codes utiles en utilisant des données IATI",
   "selectText": "Langues",
   "label": "Français",


### PR DESCRIPTION
Show a shorter title so that it fits on one line and the navigation bar can be seen when the page is in French.